### PR TITLE
IWEB-3433 - Provide an option to return a bad request status for throttled requests

### DIFF
--- a/src/JE.IdentityServer.Security.Throttling/IdentityServerThrottlingOptions.cs
+++ b/src/JE.IdentityServer.Security.Throttling/IdentityServerThrottlingOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using JE.IdentityServer.Security.OpenIdConnect;
 using JE.IdentityServer.Security.Resources;
@@ -13,6 +14,7 @@ namespace JE.IdentityServer.Security.Throttling
             ProtectedGrantTypes = Enumerable.Empty<string>();
             ExcludedUsernameExpressions = Enumerable.Empty<Regex>();
             ExcludedSubnets = Enumerable.Empty<IPNetwork>();
+            HttpRequestThrottledStatusCode = (HttpStatusCode) 429;
         }
 
         public string ProtectedPath { get; set; }
@@ -24,5 +26,7 @@ namespace JE.IdentityServer.Security.Throttling
         public IEnumerable<IPNetwork> ExcludedSubnets { get; set; }
 
         public int NumberOfAllowedLoginFailures { get; set; }
+
+        public HttpStatusCode HttpRequestThrottledStatusCode { get; set; }
     }
 }

--- a/tests/JE.IdentityServer.Security.Tests/Infrastructure/IdentityServerWithThrottledLoginRequests.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Infrastructure/IdentityServerWithThrottledLoginRequests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Text.RegularExpressions;
-using JE.IdentityServer.Security.OpenIdConnect;
 using JE.IdentityServer.Security.Resolver;
 using JE.IdentityServer.Security.Services;
 using JE.IdentityServer.Security.Throttling;
@@ -17,6 +17,7 @@ namespace JE.IdentityServer.Security.Tests.Infrastructure
         private readonly IList<Regex> _excludedUsernameExpressions = new List<Regex>();
         private readonly IList<string> _protectedGrantTypes = new List<string>();
         private TestServer _testServer;
+        private HttpStatusCode _throttledHttpStatusCode = (HttpStatusCode) 429;
 
         public LoginStatisticsStub LoginStatistics => _loginStatistics;
 
@@ -38,6 +39,12 @@ namespace JE.IdentityServer.Security.Tests.Infrastructure
             return this;
         }
 
+        public IdentityServerWithThrottledLoginRequests WithRequestsThrottledAsBadRequest()
+        {
+            _throttledHttpStatusCode = HttpStatusCode.BadRequest;
+            return this;
+        }
+
         public IdentityServerWithThrottledLoginRequests WithExcludedUsernameExpression(string excludedUsernameExpression)
         {
             _excludedUsernameExpressions.Add(new Regex(excludedUsernameExpression));
@@ -55,6 +62,7 @@ namespace JE.IdentityServer.Security.Tests.Infrastructure
                     NumberOfAllowedLoginFailures = _numberOfAllowedLoginFailures,
                     ExcludedUsernameExpressions = _excludedUsernameExpressions,
                     ProtectedGrantTypes = _protectedGrantTypes,
+                    HttpRequestThrottledStatusCode = _throttledHttpStatusCode
                 });
                 app.UseInMemoryIdentityServer();
             });


### PR DESCRIPTION
- this is to handle clients that only expect BadRequest status codes from IdentityServer