### PR TITLE
Recaptcha: added platform security triger for platform wide anomaly detection

### DIFF
--- a/src/JE.IdentityServer.Security.Recaptcha/IdentityServerRecaptchaMiddleware.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/IdentityServerRecaptchaMiddleware.cs
@@ -29,7 +29,10 @@ namespace JE.IdentityServer.Security.Recaptcha
 
             var loginStatistics = context.Get<ILoginStatistics>();
             var numberOfFailedLogins = await loginStatistics.GetNumberOfFailedLoginsForIpAddress(openIdConnectRequest.GetRemoteIpAddress());
-            if (numberOfFailedLogins < _options.NumberOfAllowedLoginFailuresPerIpAddress)
+
+            var platformSecurity = context.Get<IPlatformSecurity>();
+            var challengeForAllLogins = platformSecurity != null && await platformSecurity.ShieldsAreUp();
+            if (!challengeForAllLogins && numberOfFailedLogins < _options.NumberOfAllowedLoginFailuresPerIpAddress)
             {
                 await loginStatistics.IncrementUnchallengedLoginsForUserAndIpAddress(openIdConnectRequest.GetUsername(),
                         openIdConnectRequest.GetRemoteIpAddress(), numberOfFailedLogins, _options.NumberOfAllowedLoginFailuresPerIpAddress);

--- a/src/JE.IdentityServer.Security.Recaptcha/RecaptchaValidationMiddleware.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/RecaptchaValidationMiddleware.cs
@@ -34,9 +34,8 @@ namespace JE.IdentityServer.Security.Recaptcha
                 await Next.Invoke(context);
                 return;
             }
-
-            var platformSecurity = context.Get<IPlatformSecurity>();
-            var challengeForAllLogins = platformSecurity != null && await platformSecurity.ShieldsAreUp();
+            
+            var challengeForAllLogins = await ShouldChallengeForAllLogins(context);
             if (!challengeForAllLogins && 
                 await loginStatistics.GetNumberOfFailedLoginsForIpAddress(ipAaddress) < _options.NumberOfAllowedLoginFailuresPerIpAddress)
             {
@@ -45,6 +44,12 @@ namespace JE.IdentityServer.Security.Recaptcha
             }
             
             await ChallengeWithRequestForRecaptcha(context);
+        }
+
+        private static async Task<bool> ShouldChallengeForAllLogins(IOwinContext context)
+        {
+            var platformSecurity = context.Get<IPlatformSecurity>();
+            return platformSecurity != null && await platformSecurity.ShieldsAreUp();
         }
 
         private async Task ChallengeWithRequestForRecaptcha(IOwinContext context)

--- a/src/JE.IdentityServer.Security.Recaptcha/RecaptchaValidationMiddleware.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/RecaptchaValidationMiddleware.cs
@@ -35,8 +35,10 @@ namespace JE.IdentityServer.Security.Recaptcha
                 return;
             }
 
-            if (await loginStatistics.GetNumberOfFailedLoginsForIpAddress(ipAaddress) <
-                _options.NumberOfAllowedLoginFailuresPerIpAddress)
+            var platformSecurity = context.Get<IPlatformSecurity>();
+            var challengeForAllLogins = platformSecurity != null && await platformSecurity.ShieldsAreUp();
+            if (!challengeForAllLogins && 
+                await loginStatistics.GetNumberOfFailedLoginsForIpAddress(ipAaddress) < _options.NumberOfAllowedLoginFailuresPerIpAddress)
             {
                 await Next.Invoke(context);
                 return;

--- a/src/JE.IdentityServer.Security/JE.IdentityServer.Security.csproj
+++ b/src/JE.IdentityServer.Security/JE.IdentityServer.Security.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Resources\IPNetwork.cs" />
     <Compile Include="Resources\OpenIdConnectClient.cs" />
     <Compile Include="Services\ILoginStatistics.cs" />
+    <Compile Include="Services\IPlatformSecurity.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/src/JE.IdentityServer.Security/Services/IPlatformSecurity.cs
+++ b/src/JE.IdentityServer.Security/Services/IPlatformSecurity.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace JE.IdentityServer.Security.Services
+{
+    public interface IPlatformSecurity : IDisposable
+    {
+        Task<bool> ShieldsAreUp();
+    }
+}

--- a/tests/JE.IdentityServer.Security.Tests/Infrastructure/PlatformSecurityStub.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Infrastructure/PlatformSecurityStub.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using JE.IdentityServer.Security.Services;
+
+namespace JE.IdentityServer.Security.Tests.Infrastructure
+{
+    public class PlatformSecurityStub : IPlatformSecurity
+    {
+        private readonly bool _state;
+
+        public PlatformSecurityStub(bool state)
+        {
+            _state = state;
+        }
+
+        public Task<bool> ShieldsAreUp()
+        {
+            return Task.FromResult(_state);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/JE.IdentityServer.Security.Tests/JE.IdentityServer.Security.Tests.csproj
+++ b/tests/JE.IdentityServer.Security.Tests/JE.IdentityServer.Security.Tests.csproj
@@ -114,11 +114,13 @@
     <Compile Include="Infrastructure\NativeLoginRequestBuilder.cs" />
     <Compile Include="Infrastructure\NoDataProtector.cs" />
     <Compile Include="Infrastructure\IdentityServerWithThrottledLoginRequests.cs" />
+    <Compile Include="Infrastructure\PlatformSecurityStub.cs" />
     <Compile Include="Infrastructure\TokenFailureResponseModel.cs" />
     <Compile Include="Infrastructure\TokenResponseModel.cs" />
     <Compile Include="Recaptcha\RecaptchaResponseBodyStructure.cs" />
     <Compile Include="Recaptcha\RecaptchaValidationEndpoint.cs" />
     <Compile Include="Recaptcha\RecaptchaWithExcludedUsers.cs" />
+    <Compile Include="Recaptcha\RecaptchaWithPlatformLevelSecurity.cs" />
     <Compile Include="Recaptcha\RecaptchaWithRecaptchaServerFailures.cs" />
     <Compile Include="Recaptcha\RecaptchaWithInvalidRecaptchaAnswer.cs" />
     <Compile Include="Recaptcha\RecaptchaWithValidRecaptchaAnswer.cs" />

--- a/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithPlatformLevelSecurity.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithPlatformLevelSecurity.cs
@@ -1,0 +1,50 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using JE.IdentityServer.Security.Tests.Infrastructure;
+using NUnit.Framework;
+
+namespace JE.IdentityServer.Security.Tests.Recaptcha
+{
+    public class RecaptchaWithPlatformLevelSecurity
+    {
+        private const int NumberOfAllowedLoginFailures = 1;
+
+        [Test]
+        public async Task RecaptchaWithPlatformLevelSecurity_WithShieldsDown_ShouldNotChallenge()
+        {
+            using (var server = new IdentityServerWithRecaptcha()
+                .WithPlatformSecurityShieldsDown()
+                .WithProtectedGrantType("password")
+                .WithNumberOfAllowedLoginFailuresPerIpAddress(NumberOfAllowedLoginFailures).Build())
+            {
+                var response = await server.CreateNativeLoginRequest()
+                    .WithUsername("jeuser")
+                    .WithPassword("Passw0rd")
+                    .Build()
+                    .PostAsync();
+                response.StatusCode.Should().Be(HttpStatusCode.OK);
+                var tokenResponse = await response.Content.ReadAsAsync<TokenResponseModel>();
+                tokenResponse.AccessToken.Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Test]
+        public async Task RecaptchaWithPlatformLevelSecurity_WithShieldsUp_ShouldChallenge()
+        {
+            using (var server = new IdentityServerWithRecaptcha()
+                .WithPlatformSecurityShieldsUp()
+                .WithProtectedGrantType("password")
+                .WithNumberOfAllowedLoginFailuresPerIpAddress(NumberOfAllowedLoginFailures).Build())
+            {
+                var response = await server.CreateNativeLoginRequest()
+                    .WithUsername("jeuser")
+                    .WithPassword("Passw0rd")
+                    .Build()
+                    .PostAsync();
+                response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            }
+        }
+    }
+}


### PR DESCRIPTION
If set as a service dependency, we can check whether recaptcha is set to ON for everyone or has been triggered by an external event.