### PR TITLE
Handle raw recaptcha header

### DIFF
--- a/src/JE.IdentityServer.Security/Extensions/StringExtensions.cs
+++ b/src/JE.IdentityServer.Security/Extensions/StringExtensions.cs
@@ -12,6 +12,20 @@ namespace JE.IdentityServer.Security.Extensions
             return (base64EncodedString.Length % 4 == 0) && Regex.IsMatch(base64EncodedString, @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
         }
 
+        public static string TryToStringFromBase64String(this string base64String)
+        {
+            try
+            {
+                return string.IsNullOrEmpty(base64String)
+                    ? null
+                    : Encoding.UTF8.GetString(Convert.FromBase64String(base64String));
+            }
+            catch (FormatException)
+            {
+                return base64String;
+            }
+        }
+
         public static string ToStringFromBase64String(this string base64String)
         {
             try

--- a/src/JE.IdentityServer.Security/OpenIdConnect/KnownAcrValuesExtensions.cs
+++ b/src/JE.IdentityServer.Security/OpenIdConnect/KnownAcrValuesExtensions.cs
@@ -85,7 +85,7 @@ namespace JE.IdentityServer.Security.OpenIdConnect
         {
             try
             {
-                return JsonConvert.DeserializeObject<Device>(acrValue.ToStringFromBase64String());
+                return JsonConvert.DeserializeObject<Device>(acrValue.TryToStringFromBase64String());
             }
             catch (JsonException)
             {

--- a/src/JE.IdentityServer.Security/OpenIdConnect/OpenIdConnectRequest.cs
+++ b/src/JE.IdentityServer.Security/OpenIdConnect/OpenIdConnectRequest.cs
@@ -52,8 +52,9 @@ namespace JE.IdentityServer.Security.OpenIdConnect
         public string GetRecaptchaChallengeResponse()
         {
             var recaptchaValue = _headers.Get(RecaptchaAnswerHeaderKey);
+
             return !string.IsNullOrEmpty(recaptchaValue)
-                ? recaptchaValue.ToStringFromBase64String()
+                ? recaptchaValue.TryToStringFromBase64String()
                 : _form.Get(AcrValuesFormKey)
                     .ToKnownAcrValues().RecaptchaResponse;
         }

--- a/tests/JE.IdentityServer.Security.Tests/Infrastructure/NativeLoginRequestBuilder.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Infrastructure/NativeLoginRequestBuilder.cs
@@ -53,9 +53,14 @@ namespace JE.IdentityServer.Security.Tests.Infrastructure
             return this;
         }
 
-        public NativeLoginRequestBuilder WithHttpHeaderRecaptchaResponse(string httpHeaderRecaptchaResponse)
+        public NativeLoginRequestBuilder WithHttpHeaderRecaptchaResponseBase64(string httpHeaderRecaptchaResponse)
         {
             _headers.Add("x-recaptcha-answer", httpHeaderRecaptchaResponse.ToBase64String());
+            return this;
+        }
+        public NativeLoginRequestBuilder WithHttpHeaderRecaptchaResponseRaw(string httpHeaderRecaptchaResponse)
+        {
+            _headers.Add("x-recaptcha-answer", httpHeaderRecaptchaResponse);
             return this;
         }
 

--- a/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithInvalidRecaptchaAnswer.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithInvalidRecaptchaAnswer.cs
@@ -33,7 +33,7 @@ namespace JE.IdentityServer.Security.Tests.Recaptcha
                     var response = await server.CreateNativeLoginRequest()
                         .WithUsername("jeuser")
                         .WithPassword("Passw0rd")
-                        .WithHttpHeaderRecaptchaResponse("correct_response")
+                        .WithHttpHeaderRecaptchaResponseBase64("correct_response")
                         .Build()
                         .PostAsync();
                     response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithRecaptchaServerFailures.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithRecaptchaServerFailures.cs
@@ -30,7 +30,7 @@ namespace JE.IdentityServer.Security.Tests.Recaptcha
                     var response = await server.CreateNativeLoginRequest()
                         .WithUsername("jeuser")
                         .WithPassword("Passw0rd")
-                        .WithHttpHeaderRecaptchaResponse("correct_response")
+                        .WithHttpHeaderRecaptchaResponseBase64("correct_response")
                         .Build()
                         .PostAsync();
                     response.StatusCode.Should().Be(HttpStatusCode.OK);


### PR DESCRIPTION
This change allows for sending a recaptcha answer in plain text if there is no requirement to base64 encode the value.