### PR TITLE
Remove duplicate logging of reCAPTCHA completion

### DIFF
--- a/src/JE.IdentityServer.Security.Recaptcha/IdentityServerRecaptchaAppBuilderExtensions.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/IdentityServerRecaptchaAppBuilderExtensions.cs
@@ -21,6 +21,8 @@ namespace JE.IdentityServer.Security.Recaptcha
                 recaptchaValidationService = () => new DefaultRecaptchaValidationService();
             }
 
+            app.UsePerOwinContext<IRecaptchaTracker>(() => new RecaptchaTracker());
+
             app.UseRequestedChallengeType(options);
 
             app.UsePerOwinContext(recaptchaValidationService);

--- a/src/JE.IdentityServer.Security.Recaptcha/JE.IdentityServer.Security.Recaptcha.csproj
+++ b/src/JE.IdentityServer.Security.Recaptcha/JE.IdentityServer.Security.Recaptcha.csproj
@@ -68,6 +68,7 @@
     <Compile Include="IdentityServerRecaptchaOptions.cs" />
     <Compile Include="IIdentityServerRecaptchaOptions.cs" />
     <Compile Include="Pipeline\PipelineState.cs" />
+    <Compile Include="Pipeline\RecaptchaTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Pipeline\ValidateRecaptchaChallenge.cs" />
     <Compile Include="Services\IRecaptchaContext.cs" />

--- a/src/JE.IdentityServer.Security.Recaptcha/Pipeline/RecaptchaTracker.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/Pipeline/RecaptchaTracker.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace JE.IdentityServer.Security.Recaptcha.Pipeline
+{
+    internal interface IRecaptchaTracker : IDisposable
+    {
+        bool IsCompleted { get; set; }
+    }
+
+    internal class RecaptchaTracker : IRecaptchaTracker
+    {
+        public bool IsCompleted { get; set; }
+
+        public void Dispose() { }
+    }
+}

--- a/src/JE.IdentityServer.Security.Recaptcha/Pipeline/ValidateRecaptchaChallenge.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/Pipeline/ValidateRecaptchaChallenge.cs
@@ -26,12 +26,12 @@ namespace JE.IdentityServer.Security.Recaptcha.Pipeline
 
                 if (recaptchaVerificationResponse.Succeeded)
                 {
-                    var recaptchaContext = context.Set<IRecaptchaContext>(new RecaptchaContext(RecaptchaState.ChallengeSucceeded, recaptchaVerificationResponse.Hostname, recaptchaVerificationResponse.Timestamp));
+                    context.Set<IRecaptchaContext>(new RecaptchaContext(RecaptchaState.ChallengeSucceeded, recaptchaVerificationResponse.Hostname, recaptchaVerificationResponse.Timestamp));
                     return PipelineState.Continue;
                 }
                 else
                 {
-                    var recaptchaContext = context.Set<IRecaptchaContext>(new RecaptchaContext(RecaptchaState.Failed, recaptchaVerificationResponse.Hostname, recaptchaVerificationResponse.Timestamp));
+                    context.Set<IRecaptchaContext>(new RecaptchaContext(RecaptchaState.Failed, recaptchaVerificationResponse.Hostname, recaptchaVerificationResponse.Timestamp));
                     return PipelineState.Challenge;
                 }
             }

--- a/src/JE.IdentityServer.Security/Extensions/OwinContextExtensions.cs
+++ b/src/JE.IdentityServer.Security/Extensions/OwinContextExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using JE.IdentityServer.Security.OpenIdConnect;
 using Microsoft.Owin;

--- a/tests/JE.IdentityServer.Security.Tests/Infrastructure/RecaptchaMonitorStub.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Infrastructure/RecaptchaMonitorStub.cs
@@ -9,6 +9,7 @@ namespace JE.IdentityServer.Security.Tests.Infrastructure
         public RecaptchaResponseContext ResponseContext { get; private set; }
         public bool HasIssuedChallenge { get; private set; }
         public bool HasCompletedChallenge { get; private set; }
+        public int ChallengeCompletedInvokeCount { get; private set; }
 
         public Task ChallengeIssued(RecaptchaUserContext userContext)
         {
@@ -23,6 +24,7 @@ namespace JE.IdentityServer.Security.Tests.Infrastructure
             UserContext = userContext;
             ResponseContext = responseContext;
             HasCompletedChallenge = true;
+            ChallengeCompletedInvokeCount++;
 
             return Task.FromResult(true);
         }

--- a/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithRecaptchaServerFailures.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithRecaptchaServerFailures.cs
@@ -38,6 +38,7 @@ namespace JE.IdentityServer.Security.Tests.Recaptcha
                     response.StatusCode.Should().Be(HttpStatusCode.OK);
 
                     identityServerBuilder.RecaptchaMonitor.HasCompletedChallenge.Should().BeTrue();
+                    identityServerBuilder.RecaptchaMonitor.ChallengeCompletedInvokeCount.Should().Be(1);
                     identityServerBuilder.RecaptchaMonitor.ResponseContext.State.Should()
                         .Be(RecaptchaState.ChallengeSucceeded);
                 }

--- a/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithValidRecaptchaAnswer.cs
+++ b/tests/JE.IdentityServer.Security.Tests/Recaptcha/RecaptchaWithValidRecaptchaAnswer.cs
@@ -218,6 +218,7 @@ namespace JE.IdentityServer.Security.Tests.Recaptcha
                     response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
 
                     identityServerBuilder.RecaptchaMonitor.HasCompletedChallenge.Should().BeTrue();
+                    identityServerBuilder.RecaptchaMonitor.ChallengeCompletedInvokeCount.Should().Be(1);
                     identityServerBuilder.RecaptchaMonitor.ResponseContext.State.Should().Be(RecaptchaState.ChallengeSucceeded);
                     identityServerBuilder.RecaptchaMonitor.ResponseContext.Hostname.Should().Be("response-host-name");
                     identityServerBuilder.RecaptchaMonitor.UserContext.Username.Should().Be(username);
@@ -263,6 +264,7 @@ namespace JE.IdentityServer.Security.Tests.Recaptcha
                     response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
 
                     identityServerBuilder.RecaptchaMonitor.HasCompletedChallenge.Should().BeTrue();
+                    identityServerBuilder.RecaptchaMonitor.ChallengeCompletedInvokeCount.Should().Be(1);
                     identityServerBuilder.RecaptchaMonitor.ResponseContext.State.Should().Be(RecaptchaState.ChallengeSucceeded);
                     identityServerBuilder.RecaptchaMonitor.UserContext.ShouldBeEquivalentTo(new RecaptchaUserContext
                     {


### PR DESCRIPTION
Currently when a reCAPTCHA has been completed, the pipeline middleware will emit recaptcha completed logs and call the `ChallengeCompleted(...)` method on the `IRecaptchaMonitor` (if provided) for however many middlewares that implement `IdentityServerRecaptchaMiddlewareBase` which is currently `ChallengeEveryoneMiddleware` and `ChallengeByIp`.

This change adds in a check to see if a reCAPTCHA has been completed for a request and will then only emit the completed log / call the `ChallengeCompleted(...)` method once.