### PR TITLE
Enable injecting custom reCAPTCHA middleware

### DIFF
--- a/src/JE.IdentityServer.Security.Recaptcha/IdentityServerRecaptchaAppBuilderExtensions.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/IdentityServerRecaptchaAppBuilderExtensions.cs
@@ -27,13 +27,13 @@ namespace JE.IdentityServer.Security.Recaptcha
 
             app.UsePerOwinContext(recaptchaValidationService);
 
-            var recaptchaOptions = new RecaptchaMiddlewareBuilder(app, options);
+            var recaptchaMiddlewareBuilder = new RecaptchaMiddlewareBuilder(app, options);
 
-            recaptchaOptions.UseRecaptchaMiddleware<ValidateRecaptchaChallenge>();
-            recaptchaOptions.UseRecaptchaMiddleware<ChallengeEveryoneMiddleware>();
-            recaptchaOptions.UseRecaptchaMiddleware<ChallengeByIp>();
+            recaptchaMiddlewareBuilder.UseRecaptchaMiddleware<ValidateRecaptchaChallenge>();
+            recaptchaMiddlewareBuilder.UseRecaptchaMiddleware<ChallengeEveryoneMiddleware>();
+            recaptchaMiddlewareBuilder.UseRecaptchaMiddleware<ChallengeByIp>();
 
-            return recaptchaOptions;
+            return recaptchaMiddlewareBuilder;
         }
 
         public static IRecaptchaMiddlewareBuilder UseRecaptchaMiddleware<TMiddleware>(this IRecaptchaMiddlewareBuilder app) where TMiddleware : IdentityServerRecaptchaMiddlewareBase

--- a/src/JE.IdentityServer.Security.Recaptcha/JE.IdentityServer.Security.Recaptcha.csproj
+++ b/src/JE.IdentityServer.Security.Recaptcha/JE.IdentityServer.Security.Recaptcha.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Pipeline\RecaptchaTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Pipeline\ValidateRecaptchaChallenge.cs" />
+    <Compile Include="RecaptchaMiddlewareBuilder.cs" />
     <Compile Include="Services\IRecaptchaContext.cs" />
     <Compile Include="Services\IRecaptchaMonitor.cs" />
     <Compile Include="Services\RecaptchaContext.cs" />

--- a/src/JE.IdentityServer.Security.Recaptcha/RecaptchaMiddlewareBuilder.cs
+++ b/src/JE.IdentityServer.Security.Recaptcha/RecaptchaMiddlewareBuilder.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using Owin;
+
+namespace JE.IdentityServer.Security.Recaptcha
+{
+    public interface IRecaptchaMiddlewareBuilder : IAppBuilder
+    {
+        IdentityServerRecaptchaOptions Options { get; }
+    }
+
+    public class RecaptchaMiddlewareBuilder : IRecaptchaMiddlewareBuilder
+    {
+        private readonly IAppBuilder _appBuilder;
+
+        public RecaptchaMiddlewareBuilder(IAppBuilder appBuilder, IdentityServerRecaptchaOptions recaptchaOptions)
+        {
+            _appBuilder = appBuilder;
+            Options = recaptchaOptions;
+        }
+
+        public IAppBuilder Use(object middleware, params object[] args) => _appBuilder.Use(middleware, args);
+
+        public object Build(Type returnType) => _appBuilder.Build(returnType);
+
+        public IAppBuilder New() => _appBuilder.New();
+
+        public IDictionary<string, object> Properties => _appBuilder.Properties;
+
+        public IdentityServerRecaptchaOptions Options { get; }
+    }
+}


### PR DESCRIPTION
Adds an option to provide a custom piece of middleware which implements `IdentityServerRecaptchaMiddlewareBase` that can then be integrated into the existing pipeline.

It's a non breaking change as the default middlewares are still present and any new ones will be executed after those.